### PR TITLE
Adding a line length to the coding standards

### DIFF
--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/Files/LineLengthSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/Files/LineLengthSniff.php
@@ -28,6 +28,5 @@ class Kohana_Sniffs_Files_LineLengthSniff extends Generic_Sniffs_Files_LineLengt
      */
     protected $absoluteLineLimit = 120;
 
-}//end class
-
+}
 ?>

--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/Files/LineLengthSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/Files/LineLengthSniff.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Unit test class for LineLengthSniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Andrew Edwards <ae@eventarc.com> 
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: @release_version@ 
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Kohana_Sniffs_Files_LineLengthSniff extends Generic_Sniffs_Files_LineLengthSniff
+{
+
+    /**
+     * The number of characters allowed per line. This will give an
+     * error if breached. You can set to 0 to disable.
+     *
+     * @var int
+     */
+    protected $lineLimit = 80;
+
+    /**
+     * This is the absolute line limit allowed. Anything over this will
+     * invoke an error. You can set to 0 to disable
+     *
+     * @var int
+     */
+    protected $absoluteLineLimit = 120;
+
+}//end class
+
+?>


### PR DESCRIPTION
This will add a warning if code line length is greater than 80 and a error if line length is greater than 120. 

Perhaps this could be used as a discussion for what you think line lengths should be. We use 80 but it would be nice to use the same as Kohana.

From flicking around the different modules it seems as if different kohana dev's use different lengths.

Ref:
http://stackoverflow.com/questions/903754/do-you-still-limit-line-length-in-code
