### PR TITLE
Sniff for incomplete @param tags

### DIFF
--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/Commenting/DocBlockParamSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/Commenting/DocBlockParamSniff.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This sniff issues a warning when a \@param tag lacks the parameter name.
+ *
+ * @category    PHP
+ * @package     PHP_CodeSniffer
+ * @author      Kohana Team
+ * @copyright   (c) 2010 Kohana Team
+ * @license     http://kohanaframework.org/license
+ */
+class Kohana_Sniffs_Commenting_DocBlockParamSniff implements PHP_CodeSniffer_Sniff
+{
+    public function register()
+    {
+        return array(
+            T_DOC_COMMENT
+        );
+    }
+
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $content = $tokens[$stackPtr]['content'];
+
+        // Capture text after '@param'
+        if (preg_match('/^\s+\*\s+@param\s+(.*)$/', $content, $matches))
+        {
+            if ( ! preg_match('/^\S+\s+\$\S/', $matches[1]))
+            {
+                // Second "word" (non-whitespace) does not start with $
+                $phpcsFile->addWarning('@param tag should have the parameter name', $stackPtr);
+            }
+        }
+    }
+}

--- a/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockParamUnitTest.inc
+++ b/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockParamUnitTest.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @param type Incorrect
+ */
+
+/**
+ * @param type $var Correct
+ */
+
+/**
+ * @param int|string No name
+ * @param int|string $correct Description text
+ */
+

--- a/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockParamUnitTest.php
+++ b/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockParamUnitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Unit test class for DocBlockParamSniff.
+ *
+ * @category    PHP
+ * @package     PHP_CodeSniffer
+ * @author      Kohana Team
+ * @copyright   (c) 2010 Kohana Team
+ * @license     http://kohanaframework.org/license
+ */
+class Kohana_Tests_Commenting_DocBlockParamUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the number of errors that should occur on each line.
+     *
+     * @return  array   Array of (line => number) pairs
+     */
+    public function getErrorList()
+    {
+        return array();
+    }
+
+    /**
+     * Returns the number of warnings that should occur on each line.
+     *
+     * @return  array   Array of (line => number) pairs
+     */
+    public function getWarningList()
+    {
+        return array(
+            4 => 1,
+            12 => 1,
+        );
+    }
+}


### PR DESCRIPTION
Require existing `@param` tags to include the variable name.
