### PR TITLE
Sniff for improper use of @see tag

### DIFF
--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/Commenting/DocBlockSeeSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/Commenting/DocBlockSeeSniff.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This sniff issues a warning when a \@see tag points to a URL.
+ *
+ * @category    PHP
+ * @package     PHP_CodeSniffer
+ * @author      Kohana Team
+ * @copyright   (c) 2011 Kohana Team
+ * @license     http://kohanaframework.org/license
+ */
+class Kohana_Sniffs_Commenting_DocBlockSeeSniff implements PHP_CodeSniffer_Sniff
+{
+    public function register()
+    {
+        return array(
+            T_DOC_COMMENT
+        );
+    }
+
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $content = $tokens[$stackPtr]['content'];
+
+        if (preg_match('#^\s+\*\s+@see\s+\S+://#', $content))
+        {
+            // Text after '@see' has a scheme, a colon and two slashes
+            $phpcsFile->addWarning('@see tag should refer to code; use @link for hyperlinks', $stackPtr);
+        }
+    }
+}

--- a/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockSeeUnitTest.inc
+++ b/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockSeeUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * @see Kohana::init()
+ *
+ * @see http://www.php.net/manual/
+ */

--- a/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockSeeUnitTest.php
+++ b/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/DocBlockSeeUnitTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Unit test class for DocBlockSeeSniff.
+ *
+ * @category    PHP
+ * @package     PHP_CodeSniffer
+ * @author      Kohana Team
+ * @copyright   (c) 2011 Kohana Team
+ * @license     http://kohanaframework.org/license
+ */
+class Kohana_Tests_Commenting_DocBlockSeeUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the number of errors that should occur on each line.
+     *
+     * @return  array   Array of (line => number) pairs
+     */
+    public function getErrorList()
+    {
+        return array();
+    }
+
+    /**
+     * Returns the number of warnings that should occur on each line.
+     *
+     * @return  array   Array of (line => number) pairs
+     */
+    public function getWarningList()
+    {
+        return array(
+            6 => 1,
+        );
+    }
+}


### PR DESCRIPTION
Adds 7 warnings in 3.1/develop and 10 warnings in 3.2/develop
