### PR TITLE
Allow //@codeCoverageIgnore(Start|End) PHPUnit Tags - fixes #4317

### DIFF
--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/Commenting/OneLineCommentSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/Commenting/OneLineCommentSniff.php
@@ -50,6 +50,12 @@ class Kohana_Sniffs_Commenting_OneLineCommentSniff implements PHP_CodeSniffer_Sn
         $tokens = $phpcsFile->getTokens();
         $content = $tokens[$stackPtr]['content'];
 
+        // Allow PHPUnit Code Coverage Ignore tags
+        if (preg_match('_^//@codeCoverageIgnore(Start|End)_', $content))
+        {
+            return;
+        }
+
         if (preg_match('/^\s*(?:\/\/[^ ]|#)/', $content)) {
             $error = 'Single-line comments must begin with "// " (e.g. // My comment)';
             $phpcsFile->addError($error, $stackPtr);

--- a/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/OneLineCommentUnitTest.inc
+++ b/test/PHP_CodeSniffer/CodeSniffer/Standards/Kohana/Tests/Commenting/OneLineCommentUnitTest.inc
@@ -2,4 +2,6 @@
 // Correct
 //Incorrect
 # Incorrect
+//@codeCoverageIgnoreStart
+//@codeCoverageIgnoreEnd
 ?>


### PR DESCRIPTION
PHPUnit uses comments to control code coverage analysis within source files which are otherwise invalid per the Kohana standards (no space and do not begin with a capital letter).

This commit (including test) explicitly allows these two PHPUnit tags.

Ticket at http://dev.kohanaframework.org/issues/4317
