### PR TITLE
Added allowed type for ternary operator

### DIFF
--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/Operators/TernaryOperatorSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/Operators/TernaryOperatorSniff.php
@@ -54,6 +54,7 @@ class Kohana_Sniffs_Operators_TernaryOperatorSniff implements PHP_CodeSniffer_Sn
                 T_EQUAL,
                 T_RETURN,
                 T_ECHO,
+                T_OPEN_TAG_WITH_ECHO,
                 T_AND_EQUAL,
                 T_CONCAT_EQUAL,
                 T_DIV_EQUAL,


### PR DESCRIPTION
Bug Fix

PHP Notice:  Undefined index:  in /usr/share/php/PHP/CodeSniffer/Standards/Kohana/Sniffs/Operators/TernaryOperatorSniff.php on line 77
PHP Notice:  Undefined index:  in /usr/share/php/PHP/CodeSniffer/Standards/Kohana/Sniffs/Operators/TernaryOperatorSniff.php on line 104

Error Line: <?=isset($title)?$title:Kohana::$config->load('site.title');?>
