### PR TITLE
Add composer.json to allow installation via composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ Standard PEAR install:
 	sudo pear channel-discover pear.kohanaframework.org
 	sudo pear install kohana/PHP_CodeSniffer_Standards_Kohana
 
+## Installation - Composer
+
+Add the package to the development dependencies in your project's composer.json
+
+    {
+        "require-dev": {
+            "kohana/coding-standards": "*",
+        }
+    }
+
+Run `composer --dev update` to update your composer.lock file and install the package. The sniffs will be installed in
+`vendor/kohana/coding-standards` in your project root directory.
+
 ## Installation - If you intened to make changes to the sniff's
 
 If you want the standard to be available system wide you can symlink them into the code sniffer dir like so:
@@ -34,6 +47,18 @@ You can reference the standard like so:
 Or, if you don't want to install it system wide you can simply reference the local copy
 
 	phpcs --standard=path/to/coding-standard/PHP/CodeSniffer/Standards/Kohana system/classes/kohana
+
+If you installed with composer, reference the standard from your vendor directory:
+
+    phpcs --standard=vendor/kohana/coding-standards/PHP/CodeSniffer/Standards/Kohana
+
+## Customising your project standard
+
+It is also possible to extend the rules in use for your project, or to include some but not all of the Kohana standards
+(for example, if you are working on something that is not intended as a kohana module). You do this by adding a
+`coding_standard.xml` to your project root which specifies which rules to include and customises any variables. See the
+[PHP_CodeSniffer docs](https://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php) for more
+details.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name":        "kohana/coding-standards",
+    "require": {
+    },
+    "type":        "library",
+    "description": "PHP_CodeSniffer rules for the Kohana Framework coding style",
+    "keywords":    ["kohana", "standards", "phpcs"],
+    "homepage":    "https://github.com/kohana/coding-standards",
+    "license":     "BSD-3-Clause",
+    "authors":     [
+        {
+            "name":     "Kohana Team",
+            "email":    "team@kohanaframework.org",
+            "homepage": "http://www.kohanaframework.org",
+            "role":     "Maintainer"
+        }
+    ]
+}


### PR DESCRIPTION
It would be really helpful to be able to install the Kohana coding standards via composer so that they can be used easily in both Kohana and non-Kohana projects. I've provided and tested a composer.json and updated the readme to cover this. I wasn't sure who to list as developer/maintainer so I've just specified the Kohana team but I can easily change that if you wish.

If you accept this patch then the only remaining step would be to register the package on packagist - I'm happy to do that. After that Packagist will keep itself up to date so there shouldn't be any ongoing maintenance required.
