### PR TITLE
Disallow space indents. http://dev.kohanaframework.org/issues/4775

### DIFF
--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * CodeIgniter_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
+ * Kohana_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
  *
  * PHP version 5
  *
@@ -8,13 +8,13 @@
  * @package   PHP_CodeSniffer
  * @author    Thomas Ernest <thomas.ernest@gmail.com>
  * @copyright 2011 Thomas ERNEST
- * @license   http://thomas.ernest.fr/developement/php_cs/licence GNU General Public License
+ * @license   https://gnu.org/licenses/gpl.html GNU General Public License
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  * @link      https://github.com/thomas-ernest/CodeIgniter-for-PHP_CodeSniffer/blob/master/src/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
  */
 
 /**
- * CodeIgniter_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
+ * Kohana_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
  *
  * Ensures the use of tabs for indentation.
  *
@@ -22,8 +22,9 @@
  * @package   PHP_CodeSniffer
  * @author    Thomas Ernest <thomas.ernest@gmail.com>
  * @copyright 2011 Thomas ERNEST
- * @license   http://thomas.ernest.fr/developement/php_cs/licence GNU General Public License
+ * @license   https://gnu.org/licenses/gpl.html GNU General Public License
  * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @link      http://kohanaframework.org/3.3/guide/kohana/conventions#indentation
  */
 class Kohana_Sniffs_WhiteSpace_DisallowSpaceIndentSniff implements PHP_CodeSniffer_Sniff
 {

--- a/PHP/CodeSniffer/Standards/Kohana/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/PHP/CodeSniffer/Standards/Kohana/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * CodeIgniter_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Thomas Ernest <thomas.ernest@gmail.com>
+ * @copyright 2011 Thomas ERNEST
+ * @license   http://thomas.ernest.fr/developement/php_cs/licence GNU General Public License
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @link      https://github.com/thomas-ernest/CodeIgniter-for-PHP_CodeSniffer/blob/master/src/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+ */
+
+/**
+ * CodeIgniter_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
+ *
+ * Ensures the use of tabs for indentation.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Thomas Ernest <thomas.ernest@gmail.com>
+ * @copyright 2011 Thomas ERNEST
+ * @license   http://thomas.ernest.fr/developement/php_cs/licence GNU General Public License
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Kohana_Sniffs_WhiteSpace_DisallowSpaceIndentSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                   'JS',
+                                   'CSS',
+                                  );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_WHITESPACE);
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Make sure this is whitespace used for indentation.
+        $line = $tokens[$stackPtr]['line'];
+        if ($stackPtr > 0 && $tokens[($stackPtr - 1)]['line'] === $line) {
+            return;
+        }
+
+        if (strpos($tokens[$stackPtr]['content'], " ") !== false) {
+            $error = 'Tabs must be used to indent lines; '
+                    .'spaces are not allowed for code intendetion';
+            $phpcsFile->addError($error, $stackPtr);
+        }
+    }//end process()
+
+
+}//end class
+
+?>


### PR DESCRIPTION
Moved here from http://dev.kohanaframework.org/issues/4775

The [conventions](http://kohanaframework.org/3.3/guide/kohana/conventions#indentation) state: "You must use tabs to indent your code. Using spaces for tabbing is strictly forbidden."

Would the DisallowSpaceIndents sniff [from CodeIgniter](https://github.com/thomas-ernest/CodeIgniter-for-PHP_CodeSniffer/blob/master/src/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php) suffice?
